### PR TITLE
Fix crashes when loading older Rack patches

### DIFF
--- a/src/atsr.cpp
+++ b/src/atsr.cpp
@@ -127,11 +127,11 @@ struct Atsr : Via<ATSR_OVERSAMPLE_AMOUNT, ATSR_OVERSAMPLE_QUALITY> {
     void dataFromJson(json_t *rootJ) override {
 
         json_t *modesJ = json_object_get(rootJ, "atsr_modes");
-        virtualModule.atsrUI.modeStateBuffer = json_integer_value(modesJ);
-        virtualModule.atsrUI.loadFromEEPROM(0);
-        virtualModule.atsrUI.recallModuleState();
-
-
+        if (modesJ) {
+            virtualModule.atsrUI.modeStateBuffer = json_integer_value(modesJ);
+            virtualModule.atsrUI.loadFromEEPROM(0);
+            virtualModule.atsrUI.recallModuleState();
+        }
     }
 
     void process(const ProcessArgs &args) override;

--- a/src/gateseq.cpp
+++ b/src/gateseq.cpp
@@ -113,16 +113,19 @@ struct Gateseq : Via<GATESEQ_OVERSAMPLE_AMOUNT, GATESEQ_OVERSAMPLE_QUALITY>  {
     void dataFromJson(json_t *rootJ) override {
 
         json_t *modesJ = json_object_get(rootJ, "gateseq_modes");
-        virtualModule.gateseqUI.modeStateBuffer = json_integer_value(modesJ);
-        virtualModule.gateseqUI.loadFromEEPROM(0);
-        virtualModule.gateseqUI.recallModuleState();
+        if (modesJ) {
+            virtualModule.gateseqUI.modeStateBuffer = json_integer_value(modesJ);
+            virtualModule.gateseqUI.loadFromEEPROM(0);
+            virtualModule.gateseqUI.recallModuleState();
+        }
 
         json_t *pathJ = json_object_get(rootJ, "patterns_file");
-        patternsPath = json_string_value(pathJ);
-        virtualModule.readPatternsFromFile(patternsPath);
-        virtualModule.handleButton3ModeChange(virtualModule.gateseqUI.button3Mode);
-        virtualModule.handleButton6ModeChange(virtualModule.gateseqUI.button6Mode);
-
+        if (pathJ) {
+            patternsPath = json_string_value(pathJ);
+            virtualModule.readPatternsFromFile(patternsPath);
+            virtualModule.handleButton3ModeChange(virtualModule.gateseqUI.button3Mode);
+            virtualModule.handleButton6ModeChange(virtualModule.gateseqUI.button6Mode);
+        }
     }
     
     std::string patternsPath = asset::plugin(pluginInstance, "res/original.gateseq");

--- a/src/meta.cpp
+++ b/src/meta.cpp
@@ -160,14 +160,17 @@ struct Meta : Via<META_OVERSAMPLE_AMOUNT, META_OVERSAMPLE_QUALITY> {
     void dataFromJson(json_t *rootJ) override {
 
         json_t *modesJ = json_object_get(rootJ, "meta_modes");
-        virtualModule.metaUI.modeStateBuffer = json_integer_value(modesJ);
-        virtualModule.metaUI.loadFromEEPROM(0);
-        virtualModule.metaUI.recallModuleState();
+        if (modesJ) {
+            virtualModule.metaUI.modeStateBuffer = json_integer_value(modesJ);
+            virtualModule.metaUI.loadFromEEPROM(0);
+            virtualModule.metaUI.recallModuleState();
+        }
 
         json_t *pathJ = json_object_get(rootJ, "table_file");
-        tablePath = json_string_value(pathJ);
-        virtualModule.readTableSetFromFile(tablePath);
-
+        if (pathJ) {
+            tablePath = json_string_value(pathJ);
+            virtualModule.readTableSetFromFile(tablePath);
+        }
     }
     std::string tablePath = asset::plugin(pluginInstance, "res/original.meta");
     

--- a/src/osc3.cpp
+++ b/src/osc3.cpp
@@ -123,16 +123,22 @@ struct Osc3 : Via<OSC3_OVERSAMPLE_AMOUNT, OSC3_OVERSAMPLE_AMOUNT> {
     void dataFromJson(json_t *rootJ) override {
 
         json_t *opt = json_object_get(rootJ, "optimization");
-        optimize = json_integer_value(opt);
+        if (opt) {
+            optimize = json_integer_value(opt);            
+        }
 
         json_t *modesJ = json_object_get(rootJ, "osc_modes");
-        virtualModule.osc3UI.modeStateBuffer = json_integer_value(modesJ);
-        virtualModule.osc3UI.loadFromEEPROM(0);
-        virtualModule.osc3UI.recallModuleState();
+        if (modesJ) {
+            virtualModule.osc3UI.modeStateBuffer = json_integer_value(modesJ);
+            virtualModule.osc3UI.loadFromEEPROM(0);
+            virtualModule.osc3UI.recallModuleState();
+        }
 
         json_t *pathJ = json_object_get(rootJ, "scale_file");
-        scalePath = json_string_value(pathJ);
-        virtualModule.readScalesFromFile(scalePath);
+        if (pathJ) {
+            scalePath = json_string_value(pathJ);
+            virtualModule.readScalesFromFile(scalePath);
+        }
     }
 
     std::string scalePath = asset::plugin(pluginInstance, "res/original.osc3");

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -109,14 +109,17 @@ struct Scanner : Via<SCANNER_OVERSAMPLE_AMOUNT, SCANNER_OVERSAMPLE_QUALITY> {
     void dataFromJson(json_t *rootJ) override {
 
         json_t *modesJ = json_object_get(rootJ, "scanner_modes");
-        virtualModule.scannerUI.modeStateBuffer = json_integer_value(modesJ);
-        virtualModule.scannerUI.loadFromEEPROM(0);
-        virtualModule.scannerUI.recallModuleState();
+        if (modesJ) {
+            virtualModule.scannerUI.modeStateBuffer = json_integer_value(modesJ);
+            virtualModule.scannerUI.loadFromEEPROM(0);
+            virtualModule.scannerUI.recallModuleState();
+        }
 
         json_t *pathJ = json_object_get(rootJ, "table_file");
-        tablePath = json_string_value(pathJ);
-        virtualModule.readTableSetFromFile(tablePath);
-
+        if (pathJ) {
+            tablePath = json_string_value(pathJ);
+            virtualModule.readTableSetFromFile(tablePath);
+        }
     }
     std::string tablePath = asset::plugin(pluginInstance, "res/original.scanner");
     

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -119,14 +119,17 @@ struct Sync : Via<SYNC_OVERSAMPLE_AMOUNT, SYNC_OVERSAMPLE_QUALITY> {
     void dataFromJson(json_t *rootJ) override {
 
         json_t *modesJ = json_object_get(rootJ, "sync_modes");
-        virtualModule.syncUI.modeStateBuffer = json_integer_value(modesJ);
-        virtualModule.syncUI.loadFromEEPROM(0);
-        virtualModule.syncUI.recallModuleState();
+        if (modesJ) {
+            virtualModule.syncUI.modeStateBuffer = json_integer_value(modesJ);
+            virtualModule.syncUI.loadFromEEPROM(0);
+            virtualModule.syncUI.recallModuleState();
+        }
 
         json_t *pathJ = json_object_get(rootJ, "table_file");
-        tablePath = json_string_value(pathJ);
-        virtualModule.readTableSetFromFile(tablePath);
-
+        if (pathJ) {
+            tablePath = json_string_value(pathJ);
+            virtualModule.readTableSetFromFile(tablePath);
+        }
     }
     std::string tablePath = asset::plugin(pluginInstance, "res/original.sync");
 

--- a/src/sync3.cpp
+++ b/src/sync3.cpp
@@ -102,15 +102,18 @@ struct Sync3 : Via<SYNC3_OVERSAMPLE_AMOUNT, SYNC3_OVERSAMPLE_AMOUNT> {
     void dataFromJson(json_t *rootJ) override {
 
         json_t *modesJ = json_object_get(rootJ, "osc_modes");
-        virtualModule.sync3UI.modeStateBuffer = json_integer_value(modesJ);
-        virtualModule.sync3UI.loadFromEEPROM(0);
-        virtualModule.sync3UI.recallModuleState();
-        virtualModule.sync3UI.defaultEnterMenuCallback();
+        if (modesJ) {
+            virtualModule.sync3UI.modeStateBuffer = json_integer_value(modesJ);
+            virtualModule.sync3UI.loadFromEEPROM(0);
+            virtualModule.sync3UI.recallModuleState();
+            virtualModule.sync3UI.defaultEnterMenuCallback();
+        }
 
         json_t *pathJ = json_object_get(rootJ, "scale_file");
-        scalePath = json_string_value(pathJ);
-        virtualModule.readScalesFromFile(scalePath);
-
+        if (pathJ) {
+            scalePath = json_string_value(pathJ);
+            virtualModule.readScalesFromFile(scalePath);
+        }
     }
 
     std::string scalePath = asset::plugin(pluginInstance, "res/original.sync3");

--- a/src/sync3xl.cpp
+++ b/src/sync3xl.cpp
@@ -194,15 +194,18 @@ struct Sync3XL : Via<SYNC3_OVERSAMPLE_AMOUNT, SYNC3_OVERSAMPLE_AMOUNT> {
     void dataFromJson(json_t *rootJ) override {
 
         json_t *modesJ = json_object_get(rootJ, "osc_modes");
-        virtualModule.sync3UI.modeStateBuffer = json_integer_value(modesJ);
-        virtualModule.sync3UI.loadFromEEPROM(0);
-        virtualModule.sync3UI.recallModuleState();
-        virtualModule.sync3UI.defaultEnterMenuCallback();
+        if (modesJ) {
+            virtualModule.sync3UI.modeStateBuffer = json_integer_value(modesJ);
+            virtualModule.sync3UI.loadFromEEPROM(0);
+            virtualModule.sync3UI.recallModuleState();
+            virtualModule.sync3UI.defaultEnterMenuCallback();
+        }
 
         json_t *pathJ = json_object_get(rootJ, "scale_file");
-        scalePath = json_string_value(pathJ);
-        virtualModule.readScalesFromFile(scalePath);
-
+        if (pathJ) {
+            scalePath = json_string_value(pathJ);
+            virtualModule.readScalesFromFile(scalePath);
+        }
     }
 
     std::string scalePath = asset::plugin(pluginInstance, "res/original.sync3");


### PR DESCRIPTION
Added guards so that older patches using modules that now have a file loading option, don't crash when Rack tries to load the file path parameters (which wouldn't be present) from the JSON in the patch.

Checking for the existence of parameters in the patch is Rack module best practice, so I added them to each module.