### PR TITLE
Fix mismatched free / delete

### DIFF
--- a/src/sync3xl.cpp
+++ b/src/sync3xl.cpp
@@ -621,8 +621,8 @@ struct Sync3XL : Via<SYNC3_OVERSAMPLE_AMOUNT, SYNC3_OVERSAMPLE_AMOUNT> {
     }
 
     ~Sync3XL() {
-        free(rightExpander.producerMessage);
-        free(rightExpander.consumerMessage);
+        delete rightExpander.producerMessage;
+        delete rightExpander.consumerMessage;
     }   
 };
 

--- a/src/sync3xllevels.cpp
+++ b/src/sync3xllevels.cpp
@@ -49,8 +49,8 @@ struct Sync3XLLevels : Module {
     }
 
     ~Sync3XLLevels() {
-        free(leftExpander.producerMessage);
-        free(leftExpander.consumerMessage);
+        delete leftExpander.producerMessage;
+        delete leftExpander.consumerMessage;
     }   
 
     bool expanderAttached = false;


### PR DESCRIPTION
Caught by valgrind, these pointers are allocated with `new` so they need to use the matching `delete`

Valgrind report:
```
==150781== Mismatched free() / delete / delete []
==150781==    at 0x721DA3F: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==150781==    by 0x1FB7AAD: ~Sync3XL (sync3xl.cpp:624)
==150781==    by 0x1FB7AAD: Sync3XL::~Sync3XL() (sync3xl.cpp:626)
==150781==    by 0x263CC37: rack::app::ModuleWidget::setModule(rack::engine::Module*) (ModuleWidget.cpp:97)
==150781==    by 0x263CC70: rack::app::ModuleWidget::~ModuleWidget() (ModuleWidget.cpp:77)
==150781==    by 0x1FB6AD6: ~Sync3XLWidget (sync3xl.cpp:661)
==150781==    by 0x1FB6AD6: Sync3XLWidget::~Sync3XLWidget() (sync3xl.cpp:661)
==150781==  Address 0x2bbfa8b0 is 0 bytes inside a block of size 16 alloc'd
==150781==    at 0x721CE63: operator new(unsigned long) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==150781==    by 0x1FC3E21: Sync3XL::Sync3XL() (sync3xl.cpp:75)
```